### PR TITLE
Automatically supporting new Minecraft versions

### DIFF
--- a/src/main/java/me/jsedwards/StatusPanel.java
+++ b/src/main/java/me/jsedwards/StatusPanel.java
@@ -170,7 +170,7 @@ public class StatusPanel extends JPanel {
         thread.start();
     }
 
-    public void getJsoupFromUrl(String in, Consumer<Document> onSuccess) {
+    public static void getJsoupFromUrl(String in, Consumer<Document> onSuccess) {
         Thread thread = new Thread(() -> {
             try {
                 Document document = Jsoup.connect(in).userAgent("Mozilla").get();

--- a/src/main/java/me/jsedwards/createserver/McVersionStagePanel.java
+++ b/src/main/java/me/jsedwards/createserver/McVersionStagePanel.java
@@ -1,13 +1,34 @@
 package me.jsedwards.createserver;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import me.jsedwards.Main;
 
 import javax.swing.*;
 import java.awt.*;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 public class McVersionStagePanel extends ValidatedStage {
 
-    private static final String[] VERSIONS = {"1.8.9", "1.9", "1.9.4", "1.10", "1.10.2", "1.11", "1.11.2", "1.12", "1.12.1", "1.12.2", "1.13.2", "1.14", "1.14.1", "1.14.2", "1.14.3", "1.14.4", "1.15", "1.15.1", "1.15.2", "1.16", "1.16.1", "1.16.2", "1.16.3", "1.16.4", "1.16.5", "1.17", "1.17.1", "1.18", "1.18.1", "1.18.2", "1.19", "1.19.1", "1.19.2", "1.19.3", "1.19.4", "1.20", "1.20.1", "1.20.2", "1.20.3", "1.20.4"};
+    private static final List<String> VERSIONS;
+    static {
+        VERSIONS = new ArrayList<>();
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            ArrayNode versions = (ArrayNode) mapper.readTree(new URL("https://piston-meta.mojang.com/mc/game/version_manifest_v2.json")).get("versions");
+            for (JsonNode version : versions) {
+                if (version.get("type").textValue().equals("release")) {
+                    VERSIONS.add(version.get("id").textValue());
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     private final JComboBox<String> comboBox;
 
@@ -20,7 +41,7 @@ public class McVersionStagePanel extends ValidatedStage {
         label.setFont(Main.MAIN_FONT.deriveFont(18f));
         this.add(label, new GridBagConstraints(1, 1, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
         // Combo box
-        comboBox = new JComboBox<>(VERSIONS);
+        comboBox = new JComboBox<>(VERSIONS.toArray(new String[0]));
         this.add(comboBox, new GridBagConstraints(2, 1, 1, 1, 1, 0, GridBagConstraints.NORTHWEST, GridBagConstraints.HORIZONTAL, new Insets(0, 20, 0, 0), 0, 0));
     }
 

--- a/src/main/java/me/jsedwards/modloader/ModLoader.java
+++ b/src/main/java/me/jsedwards/modloader/ModLoader.java
@@ -196,6 +196,22 @@ public enum ModLoader {
         }
     },
     PUFFERFISH {
+        private static final Set<String> GH_BRANCHES;
+        private static final Logger LOGGER = LogManager.getLogger("Pufferfish");
+        static {
+            GH_BRANCHES = new HashSet<>();
+            ObjectMapper mapper = new ObjectMapper();
+            try {
+                ArrayNode branches = (ArrayNode) mapper.readTree(new URL("https://api.github.com/repos/pufferfish-gg/Pufferfish/branches"));
+                for (JsonNode branch : branches) {
+                    GH_BRANCHES.add(branch.get("name").textValue());
+                }
+            } catch (IOException e) {
+                LOGGER.warn("Failed to get supported Pufferfish versions");
+            }
+            LOGGER.info("Detected %s GitHub branches for Pufferfish".formatted(GH_BRANCHES.size()));
+        }
+
         @Override
         public void downloadFiles(File destination, String mcVersion, Runnable doAfter) throws IOException {
             // Pufferfish files
@@ -253,7 +269,7 @@ public enum ModLoader {
 
         @Override
         public boolean supportsVersion(String version) {
-            return MinecraftUtils.compareVersions(version, "1.17") >= 0;
+            return GH_BRANCHES.contains("ver/" + MinecraftUtils.getMajorVersion(version));
         }
     };
 

--- a/src/main/java/me/jsedwards/util/MinecraftUtils.java
+++ b/src/main/java/me/jsedwards/util/MinecraftUtils.java
@@ -56,4 +56,9 @@ public class MinecraftUtils {
     public static boolean looksLikeVersion(String s) {
         return s.matches("[0-9]+\\.[0-9]+(?:\\.[0-9]+)?");
     }
+
+    public static String getMajorVersion(String version) {
+        int[] components = convertVersion(version);
+        return "%s.%s".formatted(components[0], components[1]);
+    }
 }

--- a/src/main/java/me/jsedwards/util/MinecraftUtils.java
+++ b/src/main/java/me/jsedwards/util/MinecraftUtils.java
@@ -52,4 +52,8 @@ public class MinecraftUtils {
         }
         return nums;
     }
+
+    public static boolean looksLikeVersion(String s) {
+        return s.matches("[0-9]+\\.[0-9]+(?:\\.[0-9]+)?");
+    }
 }


### PR DESCRIPTION
Pulls all Minecraft versions from the web on startup, supported versions are no longer hard-coded for Vanilla and Forge. Fabric support more versions so they're less of an issue, and Pufferfish is too complicated at the moment. Fixes #68.